### PR TITLE
Flag --kubelet-extra-args not needed for containerd when using self m…

### DIFF
--- a/doc_source/eks-optimized-ami.md
+++ b/doc_source/eks-optimized-ami.md
@@ -232,7 +232,7 @@ You can enable the boostrap flag by creating one of the following types of node 
 + **Self\-managed** – Create the node group using the instructions in [Launching self\-managed Amazon Linux nodes](launch-workers.md)\. Specify an Amazon EKS optimized AMI and the following text for the **BootstrapArguments** parameter\.
 
   ```
-  --kubelet-extra-args --container-runtime containerd
+  --container-runtime containerd
   ```
 + **Managed** – If you use `eksctl`, create a file named *my\-nodegroup\.yaml* with the following contents\. Replace the *<example values>* with your own values\.
 


### PR DESCRIPTION
…anaged nodes

There is no need to specify --kubelet-extra-args when using self managed nodes as --container-runtime by itself a independent flag [1] and should not be specified inside --kubelet-extra-args

https://github.com/awslabs/amazon-eks-ami/blob/master/files/bootstrap.sh#L29

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
